### PR TITLE
Align Kraken2 IDs with FASTQ headers via classification output

### DIFF
--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -8,7 +8,7 @@ process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
         'biocontainers/python:3.10.4' }"
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(meta), path(reads), path(classification)
 
     output:
     tuple val(meta), path('*kraken2.map.txt'), emit: mapping
@@ -19,35 +19,41 @@ process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
 
     script:
     """
-    python - ${reads} ${meta.id}.kraken2.map.txt <<'PY'
+    python - ${reads} ${classification} ${meta.id}.kraken2.map.txt <<'PY'
 import gzip, sys
+
 
 def open_file(p):
     return gzip.open(p, 'rt') if p.endswith('.gz') else open(p, 'r')
 
-reads = sys.argv[1:-1]
+
+reads = sys.argv[1:-2]
+classification = sys.argv[-2]
 output = sys.argv[-1]
 
-with open(output, 'w') as out:
+
+with open_file(classification) as kc, open(output, 'w') as out:
     if len(reads) == 2:
         with open_file(reads[0]) as f1, open_file(reads[1]) as f2:
             while True:
-                h1 = f1.readline().rstrip()
-                h2 = f2.readline().rstrip()
-                if not h1 or not h2:
+                line = kc.readline()
+                if not line:
                     break
+                kid = line.split('\t', 2)[1].strip()
+                h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
+                h2 = f2.readline().rstrip()
                 f2.readline(); f2.readline(); f2.readline()
-                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
                 out.write(f"{kid}\\t{h1[1:]}\\t{h2[1:]}\\n")
     else:
         with open_file(reads[0]) as f1:
             while True:
-                h1 = f1.readline().rstrip()
-                if not h1:
+                line = kc.readline()
+                if not line:
                     break
+                kid = line.split('\t', 2)[1].strip()
+                h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
-                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
                 out.write(f"{kid}\\t{h1[1:]}\\n")
 PY
 

--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -39,7 +39,7 @@ with open_file(classification) as kc, open(output, 'w') as out:
                 line = kc.readline()
                 if not line:
                     break
-                kid = line.split('\t', 2)[1].strip()
+                kid = line.split('\\t', 2)[1].strip()
                 h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
                 h2 = f2.readline().rstrip()
@@ -51,7 +51,7 @@ with open_file(classification) as kc, open(output, 'w') as out:
                 line = kc.readline()
                 if not line:
                     break
-                kid = line.split('\t', 2)[1].strip()
+                kid = line.split('\\t', 2)[1].strip()
                 h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
                 out.write(f"{kid}\\t{h1[1:]}\\n")

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -165,6 +165,8 @@ workflow NFCORE_DETAXIZER {
         if ( params.filtering_tool == 'bbmap' ) {
             MAP_KRAKEN2SEQIDS_TO_FQHEADERS(
                 ch_fastq_for_classification
+                    .join(KRAKEN2_KRAKEN2.out.classified_reads_assignment, by: 0)
+                    .map { meta, reads, classification -> [meta, reads, classification] }
             )
             ch_versions = ch_versions.mix(MAP_KRAKEN2SEQIDS_TO_FQHEADERS.out.versions.first())
         }


### PR DESCRIPTION
## Summary
- Stream Kraken2 classification results alongside FASTQ headers to produce an exact ID-to-header mapping
- Update workflow to provide classification output to the mapping module

## Testing
- `pre-commit run --files modules/local/map_kraken2seqids_to_fqheaders.nf workflows/detaxizer.nf`
- `nf-test test` *(fails: Syntax errors in nf-test config file: java.net.SocketException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e83796e88322be06f363922c6a95